### PR TITLE
dirty hack for srid=900913

### DIFF
--- a/src/wfs/wfs_get_capabilities.c
+++ b/src/wfs/wfs_get_capabilities.c
@@ -320,9 +320,7 @@ static void wfs_feature_type_list(ows * o)
 
             if (srs->use) {
                 if (ows_version_get(o->request->version) == 100) {
-                    fprintf(o->output, " <SRS>");
-                    buffer_flush(srs, o->output);
-                    fprintf(o->output, "</SRS>\n");
+                    fprintf(o->output, " <SRS>EPSG:%s</SRS>\n", srid->buf);
                 } else if (ows_version_get(o->request->version) == 110) {
                     fprintf(o->output, " <DefaultSRS>urn:ogc:def:crs:EPSG::%s</DefaultSRS>\n", srid->buf);
 


### PR DESCRIPTION
Hi,

some explanations:

1) PostGIS use auth_name="spatialreferencing.org" for srid=900913 
see https://raw.github.com/postgis/postgis/svn-trunk/spatial_ref_sys.sql

2) As a result, the query

```
http://hostname/cgi-bin/tinyows?service=WFS&version=1.0.0&request=GetCapabilities
```

return:

``` xml
...
<SRS>spatialreferencing.org:900913</SRS>
...
```

3) Some programs, like QGIS, use SRS in GetFeature reguest

```
http://hostname/cgi-bin/tinyows?SERVICE=WFS&VERSION=1.0.0&REQUEST=GetFeature&TYPENAME=foo:foo&SRSNAME=spatialreferencing.org:900913
```

and tinyows return:

``` xml
<ows:ExceptionReport xsi:schemaLocation="http://www.opengis.net/ows http://schemas.opengis.net/ows/1.0.0/owsExceptionReport.xsd" version="1.1.0" language="en">
    <ows:Exception exceptionCode="InvalidParameterValue" locator="GetFeature">
        <ows:ExceptionText>srsName value use an unsupported value, for requested layer(s)</ows:ExceptionText>
    </ows:Exception>
</ows:ExceptionReport>
```

Please review and commit, thanks.

PS: there is a problem only for wfs 1.0.0
