### PR TITLE
Fix compile errors with -Wunused-but-set-variable

### DIFF
--- a/src/struct/cgi_request.c
+++ b/src/struct/cgi_request.c
@@ -81,7 +81,7 @@ char *cgi_getback_query(ows * o)
       return NULL;
     }
     s = fread(query, query_size, 1, stdin);
-    if (ferror(stdin)) {
+    if (ferror(stdin) || s == 0) {
       ows_error(o, OWS_ERROR_REQUEST_HTTP, "Error on QUERY input", "request");
       return NULL;
     }

--- a/src/wfs/wfs_transaction.c
+++ b/src/wfs/wfs_transaction.c
@@ -316,7 +316,7 @@ static buffer *wfs_retrieve_typename(ows * o, wfs_request * wr, xmlNodePtr n)
  */
 static buffer *wfs_insert_xml(ows * o, wfs_request * wr, xmlDocPtr xmldoc, xmlNodePtr n)
 {
-  buffer *values, *column, *layer_name, *layer_ns_prefix, *result, *sql, *gml;
+  buffer *values, *column, *layer_name, *result, *sql, *gml;
   buffer *handle, *id_column, *fid_full_name, *dup_sql, *id;
   xmlNodePtr node, elemt;
   filter_encoding *fe;
@@ -445,8 +445,6 @@ static buffer *wfs_insert_xml(ows * o, wfs_request * wr, xmlDocPtr xmldoc, xmlNo
       }
       list_free(l);
     }
-
-    layer_ns_prefix = ows_layer_ns_prefix(o->layers, layer_name);
 
     /* ReplaceDuplicate look if an ID is already used
      *


### PR DESCRIPTION
TinyOWS fails to build with GCC 4.7.2 on Debian Wheezy due to variables being defined and/or set but not used.  I am not sure where the -Wunused-but-set-variable flag came from other than from ./configure somehow.
