### PR TITLE
Use stdbool.h instead of custom definitions.

### DIFF
--- a/src/fe/fe_logical_ops.c
+++ b/src/fe/fe_logical_ops.c
@@ -21,6 +21,7 @@
 */
 
 
+#include <stdbool.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
@@ -101,7 +102,7 @@ static buffer *fe_unary_logical_op(ows * o, buffer * typename, filter_encoding *
   assert(n);
 
   buffer_add_str(fe->sql, "not(");
-  fe->in_not++;
+  fe->in_not = true;
 
   n = n->children;
   while (n->type != XML_ELEMENT_NODE) n = n->next;
@@ -112,7 +113,7 @@ static buffer *fe_unary_logical_op(ows * o, buffer * typename, filter_encoding *
   else if (fe_is_comparison_op((char *) n->name)) fe->sql = fe_comparison_op(o, typename, fe, n);
 
   buffer_add_str(fe->sql, ")");
-  fe->in_not--;
+  fe->in_not = false;
 
   return fe->sql;
 }

--- a/src/ows_struct.h
+++ b/src/ows_struct.h
@@ -24,17 +24,11 @@
 #ifndef OWS_STRUCT_H
 #define OWS_STRUCT_H
 
+#include <stdbool.h>
 #include <stdio.h>    /* FILE prototype */
 
 
 /* ========= Structures ========= */
-
-enum Bool {
-  false,
-  true
-};
-
-typedef enum Bool bool;
 
 #define BUFFER_SIZE_INIT   256
 


### PR DESCRIPTION
As reported in #98 tinyows fails to build with ICU 71.1 because its use of `stdbool.h` conflicts with the custom definitions in `ows_struct.h`.

To fix the `bool-operation` warnings, `true` and `false` from `stdbool.h` need to be used in `fe_logical_ops.c` as well.