### PR TITLE
Fix JSON encoding

### DIFF
--- a/src/wfs/wfs_get_feature.c
+++ b/src/wfs/wfs_get_feature.c
@@ -545,13 +545,9 @@ static buffer *wfs_retrieve_sql_request_select(ows * o, wfs_request * wr, buffer
     }
     /* Columns are written in quotation marks */
     else {
-      if (wr->format == WFS_GEOJSON)
-          buffer_add_str(select, "to_json(");
       buffer_add_str(select, "\"");
       buffer_copy(select, an->key);
       buffer_add_str(select, "\"");
-      if (wr->format == WFS_GEOJSON)
-          buffer_add_str(select, ")");
     }
 
     if (an->next) buffer_add_str(select, ",");
@@ -857,10 +853,11 @@ static void wfs_geojson_display_results(ows * o, wfs_request * wr, mlist * reque
           else buffer_add_str(prop, ", \"");
 
           buffer_copy(prop, an->key);
-          buffer_add_str(prop, "\": ");
+          buffer_add_str(prop, "\": \"");
           value_enc = buffer_encode_json_str(PQgetvalue(res, i, j));
           buffer_copy(prop, value_enc);
           buffer_free(value_enc);
+          buffer_add(prop, '"');
         }
       }
 


### PR DESCRIPTION
We experimenting bugs with JSON encoding. Double quote were not escaped correctly. GeoJSON was incorrect, while XML response was OK.

Example : 
```
{
    "type": "FeatureCollection",
    "crs": {
        "type": "name",
        "properties": {
            "name": "urn:ogc:def:crs:EPSG::4326"
        }
    },
    "features": [
        {
            "type": "Feature",
            "properties": {
                "id": 1,
                "codepostal": 62300,
                "temperature": 11,
                "nom": \"lens\"}, "geometry":{"type":"Point","bbox":[2.831830,50.428930,2.831830,50.428930],"coordinates":[2.83183,50.42893]}}
,{"type":"Feature", "properties":{"id": 2, "codepostal": 62880, "temperature": 12, "nom": \"vendin\"}, "geometry":{"type":"Point","bbox":[2.865986,50.475517,2.865986,50.475517],"coordinates":[2.865986,50.475517]}}
,{"type":"Feature", "properties":{"id": 3, "codepostal": 62680, "temperature": 14, "nom": \"mericourt\"}, "geometry":{"type":"Point","bbox":[2.866865,50.401526,2.866865,50.401526],"coordinates":[2.866865,50.401526]}}
,{"type":"Feature", "properties":{"id": 4, "codepostal": 62000, "temperature": 13, "nom": \"arras\"}, "geometry":{"type":"Point","bbox":[2.777535,50.291002,2.777535,50.291002],"coordinates":[2.777535,50.291002]}}
,{"type":"Feature", "properties":{"id": 5, "codepostal": 20000, "temperature": 24, "nom": \"ajaccio\"}, "geometry":{"type":"Point","bbox":[-74.005941,40.712784,-74.005941,40.712784],"coordinates":[-74.005941,40.712784]}}
]}
```

We propose this PR to fix that.