### PR TITLE
Include stdlib.h for atoi.

### DIFF
--- a/src/ows/ows_config.c
+++ b/src/ows/ows_config.c
@@ -22,6 +22,7 @@
 
 
 #include <stdio.h>
+#include <stdlib.h>
 #include <string.h>
 #include <assert.h>
 #include <libxml/xmlreader.h>


### PR DESCRIPTION
As reported in [Debian Bug #1072981](https://bugs.debian.org/1072981) TinyOWS fails to build:
```
make[1]: Entering directory '/build/tinyows-1.2.1'
gcc -g -O2 -Werror=implicit-function-declaration -ffile-prefix-map=/build/tinyows-1.2.1=. -fstack-protector-strong -fstack-clash-protection -Wformat -Werror=format-security -fcf-protection -Wl,-z,relro -Wl,-z,now -Wdate-time -D_FORTIFY_SOURCE=2 -std=c99 -pedantic -Wall -I/usr/include/postgresql -I/usr/include/libxml2   src/fe/fe_comparison_ops.c src/fe/fe_error.c src/fe/fe_filter.c src/fe/fe_filter_capabilities.c src/fe/fe_function.c src/fe/fe_logical_ops.c src/fe/fe_spatial_ops.c src/mapfile/mapfile.c src/ows/ows_bbox.c src/ows/ows.c src/ows/ows_config.c src/ows/ows_error.c src/ows/ows_geobbox.c src/ows/ows_get_capabilities.c src/ows/ows_layer.c src/ows/ows_metadata.c src/ows/ows_psql.c src/ows/ows_request.c src/ows/ows_srs.c src/ows/ows_storage.c src/ows/ows_version.c src/struct/alist.c src/struct/array.c src/struct/buffer.c src/struct/cgi_request.c src/struct/list.c src/struct/mlist.c src/struct/regexp.c src/wfs/wfs_describe.c src/wfs/wfs_error.c src/wfs/wfs_get_capabilities.c src/wfs/wfs_get_feature.c src/wfs/wfs_request.c src/wfs/wfs_transaction.c src/ows/ows_libxml.c -o tinyows -lfl -L/usr/lib/x86_64-linux-gnu -lpq -lxml2 -lfcgi
src/ows/ows_config.c: In function 'ows_parse_config_tinyows':
src/ows/ows_config.c:64:17: error: implicit declaration of function 'atoi'; did you mean 'atooid'? [-Werror=implicit-function-declaration]
   64 |     log_level = atoi((char *) a);
      |                 ^~~~
      |                 atooid
cc1: some warnings being treated as errors
src/ows/ows_request.c: In function 'ows_generate_schema':
src/ows/ows_request.c:143:5: warning: 'xmlSchemaCleanupTypes' is deprecated [-Wdeprecated-declarations]
  143 |     xmlSchemaCleanupTypes();
      |     ^~~~~~~~~~~~~~~~~~~~~
In file included from src/ows/ows_request.c:30:
/usr/include/libxml2/libxml/xmlschemastypes.h:37:17: note: declared here
   37 |                 xmlSchemaCleanupTypes           (void);
      |                 ^~~~~~~~~~~~~~~~~~~~~
make[1]: *** [Makefile:28: all] Error 1
make[1]: Leaving directory '/build/tinyows-1.2.1'
```

`stdlib.h` needs to be included for `atoi()`.

See also: [Porting to GCC 14 - Implicit function declarations (`-Werror=implicit-function-declaration`)](https://gcc.gnu.org/gcc-14/porting_to.html#implicit-function-declaration)